### PR TITLE
feat:add script to fix note field format in cantonese_corpus_all table

### DIFF
--- a/scripts/fix_note_field.ts
+++ b/scripts/fix_note_field.ts
@@ -1,0 +1,62 @@
+/**
+ * Script to fix the note field format in the cantonese_corpus_all table
+ * 
+ * Purpose:
+ * This script updates records in the cantonese_corpus_all table where the note field
+ * is stored as a single-element array. It extracts the first element from these arrays
+ * and updates the note field to contain just that element.
+ * 
+ * Prerequisites:
+ * 1. Deno runtime installed
+ * 2. Environment variables set:
+ *    - SUPABASE_URL: Your Supabase project URL
+ *    - SUPABASE_SERVICE_ROLE_KEY: Your Supabase service role key
+ * 3. SQL stored procedure created:
+ *    - Location: scripts/sql/fix_note_field_format.sql
+ *    - Execute this SQL file in your Supabase SQL editor before running this script
+ * 
+ * Usage:
+ * 1. Set the required environment variables:
+ *    export SUPABASE_URL='your-supabase-url'
+ *    export SUPABASE_SERVICE_ROLE_KEY='your-service-role-key'
+ * 
+ * 2. Create the stored procedure:
+ *    - Open your Supabase project
+ *    - Go to SQL Editor
+ *    - Copy and paste the contents of scripts/sql/fix_note_field_format.sql
+ *    - Execute the SQL
+ * 
+ * 3. Run the script:
+ *    deno run --allow-env --allow-net scripts/fix_note_field.ts
+ * 
+ * Note: This script requires the fix_note_field_format stored procedure to be
+ * created in your Supabase database first.
+ */
+
+// scripts/fix_note_field.ts
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error("Please set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables");
+  Deno.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+try {
+  console.log("🚀 Starting to fix note field data format...");
+
+  const { data, error } = await supabase.rpc('fix_note_field_format');
+
+  if (error) {
+    throw error;
+  }
+
+  console.log("✅ Data fix completed.");
+} catch (error) {
+  console.error("❌ Error during execution:", error);
+}

--- a/scripts/sql/fix_note_field_format.sql
+++ b/scripts/sql/fix_note_field_format.sql
@@ -1,0 +1,14 @@
+-- Create a stored procedure to fix note field format
+CREATE OR REPLACE FUNCTION fix_note_field_format()
+RETURNS void AS $$
+BEGIN
+  UPDATE public.cantonese_corpus_all
+  SET note = note->0
+  WHERE jsonb_typeof(note) = 'array'
+    AND jsonb_array_length(note) = 1;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION fix_note_field_format() TO authenticated;
+GRANT EXECUTE ON FUNCTION fix_note_field_format() TO service_role;


### PR DESCRIPTION
closes #10 
<img width="723" alt="Screenshot 2025-06-10 at 00 15 53" src="https://github.com/user-attachments/assets/63aa0e61-151b-4db8-9579-1eabe432d46a" />
<img width="438" alt="Screenshot 2025-06-10 at 10 41 28" src="https://github.com/user-attachments/assets/dfd95b15-2c21-499b-b22d-3f1937664a20" />
<img width="1159" alt="Screenshot 2025-06-10 at 10 42 13" src="https://github.com/user-attachments/assets/45b2d2c2-1372-4a10-a5a6-1d61abef67a4" />
