### PR TITLE
Add miniprogram API test script and debug improvements

### DIFF
--- a/main/app/(admin)/layout.tsx
+++ b/main/app/(admin)/layout.tsx
@@ -11,7 +11,8 @@ import {
   Database,
   LogOut,
   Menu,
-  X
+  X,
+  Code
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -33,6 +34,11 @@ const adminNavItems = [
     title: "Corpus Data", 
     href: "/admin/corpus",
     icon: Database,
+  },
+  {
+    title: "Rule Ops",
+    href: "/admin/rules",
+    icon: Code,
   },
   {
     title: "Settings",

--- a/main/lib/miniprogram-auth.ts
+++ b/main/lib/miniprogram-auth.ts
@@ -77,6 +77,18 @@ export async function requireMiniprogramMarker(
   req: NextRequest,
   handler: (req: NextRequest, user: MiniprogramTokenPayload) => Promise<NextResponse>
 ): Promise<NextResponse> {
+  if (process.env.SKIP_MINIPROGRAM_AUTH === "true") {
+    const debugUser: MiniprogramTokenPayload = {
+      userId: process.env.MINIPROGRAM_DEBUG_USER_ID ?? "local-debug-user",
+      openId: process.env.MINIPROGRAM_DEBUG_OPEN_ID ?? "local-debug-openId",
+      unionId: process.env.MINIPROGRAM_DEBUG_UNION_ID,
+      role: (process.env.MINIPROGRAM_DEBUG_ROLE as Role) ?? Role.TAGGER_PARTNER,
+      isSystemAdmin: process.env.MINIPROGRAM_DEBUG_IS_ADMIN === "true",
+    };
+
+    return handler(req, debugUser);
+  }
+
   return requireMiniprogramRole(
     req,
     [Role.TAGGER_PARTNER, Role.TAGGER_OUTSOURCING],

--- a/main/lib/services/agent.ts
+++ b/main/lib/services/agent.ts
@@ -121,7 +121,9 @@ const getAgentAuthHeader = () => {
   if (!token) {
     return {};
   }
-  return { Authorization: token.startsWith("Bearer ") ? token : `Bearer ${token}` };
+  return {
+    Authorization: token.startsWith("Bearer ") ? token : `Bearer ${token}`,
+  };
 };
 
 type AgentFetchOptions = {
@@ -131,7 +133,10 @@ type AgentFetchOptions = {
   query?: Record<string, string | number | undefined | null>;
 };
 
-async function agentFetch<T>(path: string, options: AgentFetchOptions = {}): Promise<T> {
+async function agentFetch<T>(
+  path: string,
+  options: AgentFetchOptions = {}
+): Promise<T> {
   const baseUrl = getAgentBaseUrl();
   const url = new URL(`${baseUrl}${path.startsWith("/") ? path : `/${path}`}`);
 
@@ -159,9 +164,10 @@ async function agentFetch<T>(path: string, options: AgentFetchOptions = {}): Pro
     headers["Content-Type"] = "application/json";
     init.body = JSON.stringify(options.body);
   }
-
+  console.log("agentFetch url", url.toString());
+  console.log("agentFetch init", init);
   const response = await fetch(url, init);
-
+  console.log("agentFetch response", response);
   const parsePayload = async () => {
     const text = await response.text();
     try {
@@ -181,6 +187,7 @@ async function agentFetch<T>(path: string, options: AgentFetchOptions = {}): Pro
 }
 
 export async function fetchAgentTasks(query: AgentTaskQuery) {
+  console.log("query fetchAgentTasks", query);
   return agentFetch<AgentTaskListResponse>("/tasks", {
     query: {
       actorRef: query.actorRef,
@@ -194,10 +201,15 @@ export async function fetchAgentTasks(query: AgentTaskQuery) {
 }
 
 export async function fetchAgentTask(taskId: string) {
+  console.log("taskId fetchAgentTask", taskId);
   return agentFetch<AgentTask>(`/tasks/${taskId}`);
 }
 
-export async function completeAgentTask(taskId: string, payload: { actorRef: string; selected: unknown[] }) {
+export async function completeAgentTask(
+  taskId: string,
+  payload: { actorRef: string; selected: unknown[] }
+) {
+  console.log("payload completeAgentTask", payload);
   return agentFetch(`/tasks/${taskId}/complete`, {
     method: "POST",
     body: {
@@ -207,7 +219,10 @@ export async function completeAgentTask(taskId: string, payload: { actorRef: str
   });
 }
 
-export async function skipAgentTask(taskId: string, payload: { actorRef: string }) {
+export async function skipAgentTask(
+  taskId: string,
+  payload: { actorRef: string }
+) {
   return agentFetch(`/tasks/${taskId}/skip-and-reassign`, {
     method: "POST",
     body: {
@@ -216,7 +231,13 @@ export async function skipAgentTask(taskId: string, payload: { actorRef: string 
   });
 }
 
-export async function fetchAgentRuns(query: Partial<Omit<RuleRunPayload, "ruleText">> & { page?: number; pageSize?: number; status?: string }) {
+export async function fetchAgentRuns(
+  query: Partial<Omit<RuleRunPayload, "ruleText">> & {
+    page?: number;
+    pageSize?: number;
+    status?: string;
+  }
+) {
   return agentFetch<AgentRunListResponse>("/runs", {
     query: {
       page: query.page,
@@ -245,5 +266,3 @@ export async function compileAgentRule(ruleText: string) {
 export async function fetchAgentDescriptors() {
   return agentFetch<AgentDescriptor[]>("/agents");
 }
-
-

--- a/main/package.json
+++ b/main/package.json
@@ -7,6 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
+    "test:miniprogram": "tsx scripts/test-miniprogram.ts",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
@@ -58,6 +59,7 @@
     "ethers": "^6.15.0",
     "html2canvas": "^1.4.1",
     "input-otp": "^1.4.2",
+    "jose": "6.1.2",
     "lucide-react": "^0.525.0",
     "motion": "^12.6.3",
     "next": "15.2.5",
@@ -76,18 +78,18 @@
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.2.0",
     "tw-animate-css": "^1.2.5",
+    "uuid": "13.0.0",
     "vaul": "^1.1.2",
     "vercel": "^41.6.0",
     "viem": "^2.37.4",
     "wagmi": "^2.16.9",
     "xlsx": "^0.18.5",
     "zod": "^3.24.2",
-    "zustand": "^5.0.3",
-    "uuid": "13.0.0",
-    "jose": "6.1.2"
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@next/env": "^16.0.5",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -97,6 +99,7 @@
     "prisma": "^6.8.2",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5"
+    "typescript": "^5",
+    "tsx": "^4.19.1"
   }
 }

--- a/main/pnpm-lock.yaml
+++ b/main/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@next/env':
+        specifier: ^16.0.5
+        version: 16.0.5
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
@@ -252,6 +255,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.17)
+      tsx:
+        specifier: ^4.19.1
+        version: 4.20.6
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -341,6 +347,162 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -678,6 +840,9 @@ packages:
 
   '@next/env@15.2.5':
     resolution: {integrity: sha512-uWkCf9C8wKTyQjqrNk+BA7eL3LOQdhL+xlmJUf2O85RM4lbzwBwot3Sqv2QGe/RGnc3zysIf1oJdtq9S00pkmQ==}
+
+  '@next/env@16.0.5':
+    resolution: {integrity: sha512-jRLOw822AE6aaIm9oh0NrauZEM0Vtx5xhYPgqx89txUmv/UmcRwpcXmGeQOvYNT/1bakUwA+nG5CA74upYVVDw==}
 
   '@next/eslint-plugin-next@15.2.5':
     resolution: {integrity: sha512-Q1ncASVFKSy+AbabimYxr/2HH/h+qlKlwu1fYV48xUefGzVimS3i3nKwYsM2w+rLdpMFdJyoVowrYyjKu47rBw==}
@@ -3472,6 +3637,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -3795,6 +3965,11 @@ packages:
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -5773,6 +5948,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -6475,6 +6655,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
@@ -6884,7 +7142,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.3
       uuid: 9.0.1
@@ -6898,7 +7156,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.3
       uuid: 9.0.1
@@ -6915,6 +7173,8 @@ snapshots:
     optional: true
 
   '@next/env@15.2.5': {}
+
+  '@next/env@16.0.5': {}
 
   '@next/eslint-plugin-next@15.2.5':
     dependencies:
@@ -8807,7 +9067,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       '@noble/curves': 1.9.7
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
       '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
       agentkeepalive: 4.6.0
@@ -11143,6 +11403,35 @@ snapshots:
       esbuild-windows-64: 0.14.47
       esbuild-windows-arm64: 0.14.47
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
@@ -11546,6 +11835,9 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -12709,10 +13001,10 @@ snapshots:
   ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
       abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
@@ -13781,6 +14073,13 @@ snapshots:
   tslib@2.7.0: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.20.6:
+    dependencies:
+      esbuild: 0.25.12
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tw-animate-css@1.4.0: {}
 

--- a/main/scripts/test-miniprogram.ts
+++ b/main/scripts/test-miniprogram.ts
@@ -1,0 +1,238 @@
+import { loadEnvConfig } from "@next/env";
+import { Role } from "@prisma/client";
+import { generateMiniprogramToken } from "@/lib/miniprogram-jwt";
+
+loadEnvConfig(process.cwd());
+
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
+interface TestCase {
+  name: string;
+  method: HttpMethod;
+  getPath: () => string | null;
+  body?: unknown | (() => unknown);
+}
+
+const baseUrl = process.env.MINIPROGRAM_API_BASE ?? "http://localhost:3000";
+const state = {
+  taskId: process.env.MINIPROGRAM_TEST_TASK_ID,
+  cancelTaskId:
+    process.env.MINIPROGRAM_TEST_CANCEL_TASK_ID ??
+    process.env.MINIPROGRAM_TEST_TASK_ID,
+  submitTaskId:
+    process.env.MINIPROGRAM_TEST_SUBMIT_TASK_ID ??
+    process.env.MINIPROGRAM_TEST_TASK_ID,
+};
+const submitPayload = parseJson(process.env.MINIPROGRAM_TEST_SUBMIT_PAYLOAD);
+
+const testCases: TestCase[] = [
+  {
+    name: "List completed tasks",
+    method: "GET",
+    getPath: () => "/api/miniprogram/task/completed",
+  },
+  {
+    name: "List uncompleted tasks",
+    method: "GET",
+    getPath: () => "/api/miniprogram/task/uncompleted",
+  },
+  {
+    name: "Fetch task detail",
+    method: "GET",
+    getPath: () =>
+      state.taskId
+        ? `/api/miniprogram/task/${state.taskId}`
+        : null,
+  },
+  {
+    name: "Cancel task",
+    method: "POST",
+    getPath: () =>
+      state.cancelTaskId
+        ? `/api/miniprogram/task/cancel/${state.cancelTaskId}`
+        : null,
+  },
+  {
+    name: "Submit task",
+    method: "POST",
+    getPath: () =>
+      state.submitTaskId
+        ? `/api/miniprogram/task/submit/${state.submitTaskId}`
+        : null,
+    body: () => submitPayload ?? { entries: ["demo-selection"] },
+  },
+];
+
+async function main() {
+  const results: Array<{ name: string; ok: boolean; status: number }> = [];
+  const headers = await buildHeaders();
+
+  for (const test of testCases) {
+    const path = test.getPath();
+    if (!path) {
+      console.info(`⏭️  Skip ${test.name}（缺少 taskId，等待上一请求产出）`);
+      continue;
+    }
+
+    const url = new URL(path, baseUrl);
+    try {
+      console.info(`\n▶️  ${test.name} -> ${url.toString()}`);
+      const response = await fetch(url, {
+        method: test.method,
+        headers,
+        body: formatBody(
+          typeof test.body === "function" ? test.body() : test.body
+        ),
+      });
+
+      const text = await response.text();
+      let payload: unknown;
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        payload = text;
+      }
+
+      if (response.ok) {
+        console.info("✅ Success");
+        console.dir(payload, { depth: 4 });
+        applySideEffects(test.name, payload);
+      } else {
+        console.error(`❌ Failed (${response.status})`);
+        console.dir(payload, { depth: 4 });
+      }
+
+      results.push({
+        name: test.name,
+        ok: response.ok,
+        status: response.status,
+      });
+    } catch (error) {
+      results.push({ name: test.name, ok: false, status: -1 });
+      console.error(`🔥 ${test.name} 异常:`, error);
+    }
+  }
+
+  const failed = results.filter((item) => !item.ok);
+  if (failed.length > 0) {
+    console.error(
+      `\n❗ 有 ${failed.length} 个测试失败：`,
+      failed.map((item) => `${item.name}(${item.status})`).join(", ")
+    );
+    process.exitCode = 1;
+  } else {
+    console.info("\n🎉 所有 @miniprogram 接口测试通过");
+  }
+}
+
+async function buildHeaders(): Promise<Record<string, string>> {
+  if (process.env.SKIP_MINIPROGRAM_AUTH === "true") {
+    return {
+      "Content-Type": "application/json",
+    };
+  }
+
+  const token =
+    process.env.MINIPROGRAM_TEST_TOKEN ??
+    (await generateMiniprogramToken({
+      userId: process.env.MINIPROGRAM_DEBUG_USER_ID ?? "local-debug-user",
+      openId: process.env.MINIPROGRAM_DEBUG_OPEN_ID ?? "local-debug-openId",
+      unionId: process.env.MINIPROGRAM_DEBUG_UNION_ID,
+      role: parseRole(process.env.MINIPROGRAM_DEBUG_ROLE),
+      isSystemAdmin: process.env.MINIPROGRAM_DEBUG_IS_ADMIN === "true",
+    }));
+
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+function formatBody(body?: unknown) {
+  if (body === undefined || body === null) {
+    return undefined;
+  }
+
+  if (typeof body === "string") {
+    return body;
+  }
+
+  return JSON.stringify(body);
+}
+
+function parseJson(value?: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    console.warn("⚠️  MINIPROGRAM_TEST_SUBMIT_PAYLOAD 不是合法 JSON，已忽略");
+    return undefined;
+  }
+}
+
+function parseRole(raw?: string): Role {
+  if (!raw) return Role.TAGGER_PARTNER;
+  const upper = raw.toUpperCase();
+  return (Role as Record<string, Role>)[upper] ?? Role.TAGGER_PARTNER;
+}
+
+function applySideEffects(testName: string, payload: unknown) {
+  if (testName !== "List uncompleted tasks") {
+    return;
+  }
+
+  if (state.taskId && state.cancelTaskId && state.submitTaskId) {
+    return;
+  }
+
+  const fallbackIds = extractTaskIds(payload);
+  const [firstId] = fallbackIds;
+
+  if (!firstId) {
+    console.warn("⚠️  未能从未完成任务列表中提取 taskId");
+    return;
+  }
+
+  if (!state.taskId) {
+    state.taskId = firstId;
+    console.info(`ℹ️  设定 taskId=${firstId}`);
+  }
+  if (!state.cancelTaskId) {
+    state.cancelTaskId = firstId;
+    console.info(`ℹ️  设定 cancelTaskId=${firstId}`);
+  }
+  if (!state.submitTaskId) {
+    state.submitTaskId = firstId;
+    console.info(`ℹ️  设定 submitTaskId=${firstId}`);
+  }
+}
+
+function extractTaskIds(payload: unknown): string[] {
+  if (!payload) return [];
+
+  if (Array.isArray(payload)) {
+    return payload
+      .map((item) => (typeof item === "object" && item ? (item as any).taskId : undefined))
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null
+  ) {
+    const data = (payload as any).data;
+    if (Array.isArray(data)) {
+      return data
+        .map((item) => (typeof item === "object" && item ? (item as any).taskId : undefined))
+        .filter((id): id is string => typeof id === "string" && id.length > 0);
+    }
+  }
+
+  return [];
+}
+
+void main();
+


### PR DESCRIPTION
Introduces scripts/test-miniprogram.ts for automated testing of miniprogram API endpoints. Adds SKIP_MINIPROGRAM_AUTH support and debug user injection to miniprogram-auth, improves logging in agent service functions, updates dependencies, and adds related npm scripts.