### PR TITLE
Add API route to mark agent task as viewed

### DIFF
--- a/main/app/api/miniprogram/task/[id]/view/route.ts
+++ b/main/app/api/miniprogram/task/[id]/view/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AppRouteContext, getStringRouteParam } from "@/lib/app-route-context";
+import { requireMiniprogramMarker } from "@/lib/miniprogram-auth";
+import { viewAgentTask } from "@/lib/services/agent";
+import { handleAgentApiError } from "@/lib/services/agent-error";
+
+interface ViewTaskPayload {
+  actorRef: string;
+}
+
+export async function POST(
+  req: NextRequest,
+  context: AppRouteContext
+) {
+  return requireMiniprogramMarker(req, async () => {
+    const taskId = await getStringRouteParam(context, "id");
+    
+    if (!taskId) {
+      return NextResponse.json(
+        { error: "Missing task id" },
+        { status: 400 }
+      );
+    }
+
+    try {
+      const payload: ViewTaskPayload = await req.json();
+      
+      if (!payload.actorRef) {
+        return NextResponse.json(
+          { error: "Missing actorRef" },
+          { status: 400 }
+        );
+      }
+
+      const result = await viewAgentTask(taskId, {
+        actorRef: payload.actorRef,
+      });
+
+      return NextResponse.json(result);
+    } catch (error) {
+      return handleAgentApiError(error, "Failed to mark task as viewed");
+    }
+  });
+}

--- a/main/lib/miniprogram-auth.ts
+++ b/main/lib/miniprogram-auth.ts
@@ -91,7 +91,7 @@ export async function requireMiniprogramMarker(
 
   return requireMiniprogramRole(
     req,
-    [Role.TAGGER_PARTNER, Role.TAGGER_OUTSOURCING],
+    [Role.TAGGER_PARTNER, Role.TAGGER_OUTSOURCING, Role.RESEARCHER],
     handler
   );
 }

--- a/main/lib/services/agent.ts
+++ b/main/lib/services/agent.ts
@@ -219,11 +219,24 @@ export async function completeAgentTask(
   });
 }
 
+
 export async function skipAgentTask(
   taskId: string,
   payload: { actorRef: string }
 ) {
   return agentFetch(`/tasks/${taskId}/skip-and-reassign`, {
+    method: "POST",
+    body: {
+      actorRef: payload.actorRef,
+    },
+  });
+}
+
+export async function viewAgentTask(
+  taskId: string,
+  payload: { actorRef: string }
+) {
+  return agentFetch(`/tasks/${taskId}/view`, {
     method: "POST",
     body: {
       actorRef: payload.actorRef,


### PR DESCRIPTION
Introduces a new POST endpoint at /api/miniprogram/task/[id]/view to mark a task as viewed by an actor. Adds the viewAgentTask service function and updates miniprogram auth to allow RESEARCHER role access.