### PR TITLE
Add lifecycle_stage filtering for /all_items

### DIFF
--- a/deno/apidoc.md
+++ b/deno/apidoc.md
@@ -364,6 +364,13 @@ Retrieves all corpus items from a specified corpus.
 - `corpus_name` (required): The name of the corpus to get a random item from (e.g., "yyjq")
 - `cursor` (optional): Indicating that data after the cursor is retrieved.
 - `limit` (optional): Maximum number of results to return
+- `lifecycle_stage` (optional): Filter by lifecycle stage. Supports multiple values via repeated parameters or comma-separated lists.
+
+**lifecycle_stage available values:**
+- `draft`: Not yet entered any processing flow
+- `normalized`: Automated normalization completed
+- `cleaned`: Manual cleaning completed
+- `active`: Entered routine rule checks
 
 **Response:**
 ```json
@@ -384,6 +391,11 @@ Retrieves all corpus items from a specified corpus.
 **Curl Example:**
 ```bash
 curl -X GET "https://backend.aidimsum.com/all_items?corpus_name=yyjq&cursor=0&limit=2"
+```
+
+**Curl Example (Filter):**
+```bash
+curl -X GET "https://backend.aidimsum.com/all_items?corpus_name=yyjq&lifecycle_stage=normalized&lifecycle_stage=draft"
 ```
 
 ## Developer APIs (API Key Required)

--- a/deno/main.tsx
+++ b/deno/main.tsx
@@ -325,6 +325,11 @@ router
     const corpus_name = queryParams.get("corpus_name");
     const limit = queryParams.get("limit") || "100";
     const cursor = queryParams.get("cursor");
+    const lifecycleStageParams = queryParams.getAll("lifecycle_stage");
+    const lifecycleStageList = lifecycleStageParams
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
 
     // Validate corpus_name parameter
     if (!corpus_name) {
@@ -351,6 +356,10 @@ router
         .eq("category", corpus_name)
         .order("id", { ascending: true })
         .limit(limitNum);
+
+      if (lifecycleStageList.length > 0) {
+        query = query.in("lifecycle_stage", lifecycleStageList);
+      }
 
       // Add cursor-based pagination if cursor is provided
       if (cursor) {


### PR DESCRIPTION
 /all_items 增加一个 `lifecycle_stage` 的筛选参数，主要用来只查询清洗后的语料库数据。