### PR TITLE
Refactor responsive header, nav & profile UI

### DIFF
--- a/main/app/[locale]/(account)/account/profile/page.tsx
+++ b/main/app/[locale]/(account)/account/profile/page.tsx
@@ -72,8 +72,8 @@ export default function ProfilePage() {
   return (
     <>
       <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-3xl font-bold">{t("title")}</h1>
+        <div className="flex items-center justify-between mb-6 sm:mb-8">
+          <h1 className="text-2xl sm:text-3xl font-bold">{t("title")}</h1>
         </div>
 
         {loading && (
@@ -86,7 +86,7 @@ export default function ProfilePage() {
                   <Skeleton className="h-4 w-32" />
                 </div>
               </div>
-              <div className="grid grid-cols-2 gap-4 mt-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6">
                 <Skeleton className="h-4 w-24" />
                 <Skeleton className="h-4 w-24" />
               </div>
@@ -106,7 +106,7 @@ export default function ProfilePage() {
         {profile && !loading && (
           <div className="grid gap-6">
             <Card className="p-6 bg-card transition-all duration-200 hover:shadow-lg">
-              <div className="flex items-center space-x-6">
+              <div className="flex flex-col items-center sm:flex-row sm:items-center sm:space-x-6">
                 <div className="relative">
                   {profile.image || profile.wechatAvatar ? (
                     <Image
@@ -114,42 +114,44 @@ export default function ProfilePage() {
                       alt={profile.name}
                       width={96}
                       height={96}
-                      className="w-24 h-24 rounded-full object-cover border-4 border-background shadow-lg"
+                      className="w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover border-4 border-background shadow-lg"
                     />
                   ) : (
-                    <div className="w-24 h-24 rounded-full bg-gradient-to-br from-primary to-primary/80 flex items-center justify-center shadow-lg">
+                    <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-gradient-to-br from-primary to-primary/80 flex items-center justify-center shadow-lg">
                       <span className="text-3xl font-bold">
                         {profile.name.charAt(0).toUpperCase()}
                       </span>
                     </div>
                   )}
                 </div>
-                <div className="flex-1">
-                  <div className="flex items-center space-x-3">
-                    <h2 className="text-2xl font-bold">{profile.name}</h2>
-                    <Badge variant="secondary" className="text-sm">
-                      {formatRole(profile.role)}
-                    </Badge>
-                    {profile.isSystemAdmin && (
-                      <Badge variant="destructive" className="text-sm">
-                        {t("systemAdmin")}
+                <div className="flex-1 text-center sm:text-left mt-4 sm:mt-0">
+                  <div className="flex flex-col items-center sm:flex-row sm:items-center gap-2 sm:gap-3">
+                    <h2 className="text-xl sm:text-2xl font-bold">{profile.name}</h2>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary" className="text-sm">
+                        {formatRole(profile.role)}
                       </Badge>
-                    )}
-                    {profile && (
-                      <EditProfileDialog
-                        profile={profile}
-                        onProfileUpdate={handleProfileUpdate}
-                      />
-                    )}
+                      {profile.isSystemAdmin && (
+                        <Badge variant="destructive" className="text-sm">
+                          {t("systemAdmin")}
+                        </Badge>
+                      )}
+                      {profile && (
+                        <EditProfileDialog
+                          profile={profile}
+                          onProfileUpdate={handleProfileUpdate}
+                        />
+                      )}
+                    </div>
                   </div>
 
                   <div className="mt-2 space-y-2">
-                    <div className="flex items-center text-muted-foreground">
-                      <Mail className="w-4 h-4 mr-2" />
-                      <span>{profile.email || t("notSet")}</span>
+                    <div className="flex items-center justify-center sm:justify-start text-muted-foreground">
+                      <Mail className="w-4 h-4 mr-2 shrink-0" />
+                      <span className="truncate">{profile.email || t("notSet")}</span>
                     </div>
-                    <div className="flex items-center text-muted-foreground">
-                      <Phone className="w-4 h-4 mr-2" />
+                    <div className="flex items-center justify-center sm:justify-start flex-wrap text-muted-foreground">
+                      <Phone className="w-4 h-4 mr-2 shrink-0" />
                       <span>{profile.phoneNumber || t("notSet")}</span>
                       {profile.phoneNumber ? (
                         <Button
@@ -173,9 +175,9 @@ export default function ProfilePage() {
                         </Button>
                       )}
                     </div>
-                    <div className="flex items-center justify-start text-muted-foreground">
-                      <div className="flex items-center">
-                        <Wallet className="w-4 h-4 mr-2" />
+                    <div className="flex items-center justify-center sm:justify-start flex-wrap gap-y-1 text-muted-foreground">
+                      <div className="flex items-center min-w-0">
+                        <Wallet className="w-4 h-4 mr-2 shrink-0" />
                         {profile.ethAddress ? (
                           <TooltipProvider>
                             <div className="flex items-center space-x-2">

--- a/main/app/[locale]/(home)/page.tsx
+++ b/main/app/[locale]/(home)/page.tsx
@@ -48,6 +48,7 @@ export default function HomePage() {
   const [selectedDataset, setSelectedDataset] = useState<string[]>(["all"]);
   const [datasetInputValue, setDatasetInputValue] = useState("");
   const [luckyHovered, setLuckyHovered] = useState(false);
+  const [searchFocused, setSearchFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { data: categories } = useAllCategories();
@@ -229,7 +230,11 @@ export default function HomePage() {
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.15 }}
-          className="relative mt-6 w-full max-w-[720px]"
+          className={cn(
+            "relative mt-6 w-full max-w-[720px]",
+            "transition-transform duration-200 origin-top",
+            searchFocused && "max-sm:scale-[1.06]"
+          )}
         >
           {/* Search card with border glow — dropdown is inside the same card */}
           <BorderGlow
@@ -254,9 +259,13 @@ export default function HomePage() {
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   onKeyDown={handleKeyDown}
-                  onFocus={handleFocus}
+                  onFocus={() => {
+                    handleFocus();
+                    setSearchFocused(true);
+                  }}
+                  onBlur={() => setSearchFocused(false)}
                   placeholder={t("searchPlaceholder")}
-                  className="flex-1 h-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                  className="flex-1 h-full bg-transparent text-base outline-none placeholder:text-muted-foreground"
                 />
               </div>
 

--- a/main/components/layout/floating-nav.tsx
+++ b/main/components/layout/floating-nav.tsx
@@ -59,9 +59,10 @@ export function FloatingNav() {
 
   return (
     <>
-      <nav className="fixed top-4 right-6 z-50 flex items-center gap-4">
+      {/* Desktop nav — right-aligned */}
+      <nav className="hidden md:flex fixed top-4 right-6 z-50 items-center gap-4">
         {/* Desktop nav links */}
-        <div className="hidden md:flex items-center gap-4">
+        <div className="flex items-center gap-4">
           {navLinks.map((link) => (
             <Link
               key={link.href}
@@ -73,11 +74,8 @@ export function FloatingNav() {
           ))}
         </div>
 
-        {/* Locale + Theme toggle — hidden on mobile, shown in hamburger drawer */}
-        <span className="hidden md:contents">
-          <LocaleSwitcher />
-          <ThemeToggle />
-        </span>
+        <LocaleSwitcher />
+        <ThemeToggle />
 
         {/* User menu / Sign In */}
         {isAuthenticated ? (
@@ -90,7 +88,7 @@ export function FloatingNav() {
                     {user?.name?.[0] || "U"}
                   </AvatarFallback>
                 </Avatar>
-                <span className="hidden sm:inline text-sm">{user?.name || "User"}</span>
+                <span className="text-sm">{user?.name || "User"}</span>
                 <ChevronDown className="h-3 w-3 text-muted-foreground" />
               </Button>
             </DropdownMenuTrigger>
@@ -133,11 +131,14 @@ export function FloatingNav() {
             {tCommon('signIn')}
           </Button>
         )}
+      </nav>
 
-        {/* Mobile hamburger */}
+      {/* Mobile nav — hamburger left, user right */}
+      <nav className="md:hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 h-14">
+        {/* Left: Hamburger */}
         <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
           <SheetTrigger asChild>
-            <Button variant="ghost" size="icon" className="md:hidden h-8 w-8">
+            <Button variant="ghost" size="icon" className="h-10 w-10">
               <Menu className="h-5 w-5" />
             </Button>
           </SheetTrigger>
@@ -159,6 +160,59 @@ export function FloatingNav() {
             </div>
           </SheetContent>
         </Sheet>
+
+        {/* Right: User */}
+        {isAuthenticated ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-10 w-10">
+                <Avatar className="h-6 w-6">
+                  <AvatarImage src={user?.avatar || ""} alt={user?.name || ""} />
+                  <AvatarFallback className="text-xs">
+                    {user?.name?.[0] || "U"}
+                  </AvatarFallback>
+                </Avatar>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              {accountSubmenuItems.map((item) => (
+                <DropdownMenuItem key={item.href} onClick={() => router.push(item.href)}>
+                  <item.icon className="mr-2 h-4 w-4" />
+                  {t(item.labelKey)}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              {workplaceSubmenuItems.map((item) => (
+                <DropdownMenuItem key={item.href} onClick={() => router.push(item.href)}>
+                  <item.icon className="mr-2 h-4 w-4" />
+                  {t(item.labelKey)}
+                </DropdownMenuItem>
+              ))}
+              {session?.user?.isSystemAdmin && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => window.open('/admin', '_blank')}>
+                    <Settings className="mr-2 h-4 w-4" />
+                    {t('admin')}
+                  </DropdownMenuItem>
+                </>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleLogout}>
+                <LogOut className="mr-2 h-4 w-4" />
+                {tCommon('signOut')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => setShowRoleSelect(true)}
+          >
+            {tCommon('signIn')}
+          </Button>
+        )}
       </nav>
 
       {/* Auth dialogs */}

--- a/main/components/layout/header.tsx
+++ b/main/components/layout/header.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle/theme-toggle";
 import { LocaleSwitcher } from "@/components/locale-switcher";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { HamburgerMenuContent } from "@/components/layout/hamburger-menu-content";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,6 +35,26 @@ const allNavLinks = [
   { labelKey: "docs", href: "/docs" },
 ];
 
+function MobileSheetContent({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex h-14 items-center border-b px-4">
+        <Image
+          src="/logo.png"
+          alt="DimSum AI Labs Logo"
+          width={24}
+          height={24}
+          className="rounded-sm"
+        />
+        <span className="ml-2 text-sm font-medium">DimSum AI</span>
+      </div>
+      <nav className="flex-1 overflow-auto py-4 px-3 space-y-1">
+        <HamburgerMenuContent onNavClick={onClose} />
+      </nav>
+    </div>
+  );
+}
+
 export function Header() {
   const pathname = usePathname();
   const router = useRouter();
@@ -43,8 +64,8 @@ export function Header() {
   const [showRoleSelect, setShowRoleSelect] = useState(false);
   const [showLoginDialog, setShowLoginDialog] = useState(false);
   const [selectedRole, setSelectedRole] = useState<UserRole | null>(null);
-  const t = useTranslations('Nav');
-  const tCommon = useTranslations('Common');
+  const t = useTranslations("Nav");
+  const tCommon = useTranslations("Common");
 
   const accountSubmenuItems = getAccountSubmenuItems(user?.role as Role);
 
@@ -64,10 +85,76 @@ export function Header() {
     return pathname.startsWith(href);
   };
 
+  /* ── Shared user menu (used in both desktop and mobile) ─────────── */
+  const userMenu = isAuthenticated ? (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="gap-1.5">
+          <Avatar className="h-6 w-6">
+            <AvatarImage src={user?.avatar || ""} alt={user?.name || ""} />
+            <AvatarFallback className="text-xs">
+              {user?.name?.[0] || "U"}
+            </AvatarFallback>
+          </Avatar>
+          <span className="hidden sm:inline text-sm">
+            {user?.name || "User"}
+          </span>
+          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        {accountSubmenuItems.map((item) => (
+          <DropdownMenuItem
+            key={item.href}
+            onClick={() => router.push(item.href)}
+          >
+            <item.icon className="mr-2 h-4 w-4" />
+            {t(item.labelKey)}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        {workplaceSubmenuItems.map((item) => (
+          <DropdownMenuItem
+            key={item.href}
+            onClick={() => router.push(item.href)}
+          >
+            <item.icon className="mr-2 h-4 w-4" />
+            {t(item.labelKey)}
+          </DropdownMenuItem>
+        ))}
+        {session?.user?.isSystemAdmin && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => window.open("/admin", "_blank")}
+            >
+              <Settings className="mr-2 h-4 w-4" />
+              {t("admin")}
+            </DropdownMenuItem>
+          </>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleLogout}>
+          <LogOut className="mr-2 h-4 w-4" />
+          {tCommon("signOut")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ) : (
+    <Button
+      variant="default"
+      size="sm"
+      onClick={() => setShowRoleSelect(true)}
+    >
+      {tCommon("signIn")}
+    </Button>
+  );
+
   return (
     <>
       <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur-md">
-        <div className="container mx-auto px-4 flex h-14 items-center justify-between">
+        {/* ── Desktop & Tablet Layout — Single Row ──────────────────── */}
+        <div className="hidden sm:flex items-center justify-between h-14 container mx-auto px-4">
           {/* Left: Logo + Nav */}
           <div className="flex items-center gap-6">
             <Link href="/" className="flex items-center gap-2">
@@ -78,9 +165,7 @@ export function Header() {
                 height={28}
                 className="w-7 h-7"
               />
-              <span className="font-semibold text-foreground hidden sm:inline">
-                DimSum AI
-              </span>
+              <span className="font-semibold text-foreground">DimSum AI</span>
             </Link>
 
             {/* Desktop nav links */}
@@ -93,7 +178,7 @@ export function Header() {
                     "px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
                     isActive(link.href)
                       ? "text-foreground bg-accent"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
                   )}
                 >
                   {t(link.labelKey)}
@@ -102,116 +187,64 @@ export function Header() {
             </nav>
           </div>
 
-          {/* Right: Theme + User */}
+          {/* Right: Locale + Theme + User + Hamburger (tablet only) */}
           <div className="flex items-center gap-2">
             <LocaleSwitcher />
             <ThemeToggle />
+            {userMenu}
 
-            {/* User menu */}
-            {isAuthenticated ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm" className="gap-1.5">
-                    <Avatar className="h-6 w-6">
-                      <AvatarImage src={user?.avatar || ""} alt={user?.name || ""} />
-                      <AvatarFallback className="text-xs">
-                        {user?.name?.[0] || "U"}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span className="hidden sm:inline text-sm">{user?.name || "User"}</span>
-                    <ChevronDown className="h-3 w-3 text-muted-foreground" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-48">
-                  {accountSubmenuItems.map((item) => (
-                    <DropdownMenuItem key={item.href} onSelect={() => router.push(item.href)}>
-                      <item.icon className="mr-2 h-4 w-4" />
-                      {t(item.labelKey)}
-                    </DropdownMenuItem>
-                  ))}
-                  <DropdownMenuSeparator />
-                  {workplaceSubmenuItems.map((item) => (
-                    <DropdownMenuItem key={item.href} onSelect={() => router.push(item.href)}>
-                      <item.icon className="mr-2 h-4 w-4" />
-                      {t(item.labelKey)}
-                    </DropdownMenuItem>
-                  ))}
-                  {session?.user?.isSystemAdmin && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={() => window.open('/admin', '_blank')}>
-                        <Settings className="mr-2 h-4 w-4" />
-                        {t('admin')}
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={handleLogout}>
-                    <LogOut className="mr-2 h-4 w-4" />
-                    {tCommon('signOut')}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button
-                variant="default"
-                size="sm"
-                onClick={() => setShowRoleSelect(true)}
-              >
-                {tCommon('signIn')}
-              </Button>
-            )}
-
-            {/* Mobile hamburger */}
+            {/* Tablet hamburger (below md, nav links hidden) */}
             <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
               <SheetTrigger asChild>
-                <Button variant="ghost" size="icon" className="md:hidden">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="md:hidden h-9 w-9"
+                >
                   <Menu className="h-5 w-5" />
                 </Button>
               </SheetTrigger>
               <SheetContent side="right" className="w-64 p-0">
-                <div className="flex flex-col h-full">
-                  <div className="flex h-14 items-center border-b px-4">
-                    <Image
-                      src="/logo.png"
-                      alt="DimSum AI Labs Logo"
-                      width={24}
-                      height={24}
-                      className="rounded-sm"
-                    />
-                    <span className="ml-2 text-sm font-medium">DimSum AI</span>
-                  </div>
-                  <nav className="flex-1 overflow-auto py-4 px-3 space-y-1">
-                    {allNavLinks.map((link) => (
-                      <Link
-                        key={link.href}
-                        href={link.href}
-                        onClick={() => setMobileOpen(false)}
-                        className={cn(
-                          "flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors",
-                          isActive(link.href)
-                            ? "text-foreground bg-accent"
-                            : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                        )}
-                      >
-                        {t(link.labelKey)}
-                      </Link>
-                    ))}
-                    {session?.user?.isSystemAdmin && (
-                      <Link
-                        href="/admin"
-                        target="_blank"
-                        onClick={() => setMobileOpen(false)}
-                        className="flex items-center px-3 py-2 text-sm font-medium rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                      >
-                        <Settings className="w-4 h-4 mr-2" />
-                        {t('admin')}
-                      </Link>
-                    )}
-                  </nav>
-                </div>
+                <MobileSheetContent onClose={() => setMobileOpen(false)} />
               </SheetContent>
             </Sheet>
+          </div>
+        </div>
+
+        {/* ── Mobile Layout — Two Rows (matches SearchHeader) ──────── */}
+        <div className="sm:hidden">
+          {/* Row 1: Hamburger | Logo (centered) | User */}
+          <div className="grid grid-cols-3 items-center h-14 px-4">
+            {/* Left: Hamburger */}
+            <div className="flex justify-start">
+              <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+                <SheetTrigger asChild>
+                  <Button variant="ghost" size="icon" className="h-10 w-10">
+                    <Menu className="h-5 w-5" />
+                  </Button>
+                </SheetTrigger>
+                <SheetContent side="right" className="w-64 p-0">
+                  <MobileSheetContent onClose={() => setMobileOpen(false)} />
+                </SheetContent>
+              </Sheet>
+            </div>
+
+            {/* Center: Logo */}
+            <div className="flex justify-center">
+              <Link href="/" className="flex items-center gap-2">
+                <Image
+                  src="/logo.png"
+                  alt="DimSum AI Labs"
+                  width={28}
+                  height={28}
+                  className="rounded-sm"
+                />
+                <span className="text-base font-semibold">DimSum</span>
+              </Link>
+            </div>
+
+            {/* Right: User */}
+            <div className="flex justify-end">{userMenu}</div>
           </div>
         </div>
       </header>

--- a/main/components/layout/search-header.tsx
+++ b/main/components/layout/search-header.tsx
@@ -9,6 +9,7 @@ import {
   X,
   SlidersHorizontal,
   Menu,
+  EllipsisVertical,
   ChevronDown,
   Settings,
   LogOut,
@@ -139,6 +140,7 @@ function SearchInputField({
   tSearch,
   dropdownState,
 }: SearchInputProps) {
+  const [isFocused, setIsFocused] = useState(false);
   const isGlobal = selectedDataset.includes("all");
   const allCategory = categories.find((cat) => cat.name === "all");
   const specificCategories = categories.filter((cat) => cat.name !== "all");
@@ -167,7 +169,11 @@ function SearchInputField({
   return (
     <div className="relative">
       {/* Pill input bar */}
-      <div className="relative flex items-center rounded-full bg-muted/50 border border-border shadow-sm transition-all hover:bg-muted focus-within:bg-muted focus-within:ring-1 focus-within:ring-ring">
+      <div className={cn(
+        "relative flex items-center rounded-full bg-muted/50 border border-border shadow-sm transition-all hover:bg-muted focus-within:bg-muted focus-within:ring-1 focus-within:ring-ring",
+        "sm:transform-none transition-transform duration-200 origin-top",
+        isFocused && "max-sm:scale-[1.03]"
+      )}>
         {/* Search icon */}
         <div className="pl-3 flex items-center pointer-events-none shrink-0">
           <Search className="h-4 w-4 text-muted-foreground" />
@@ -179,7 +185,6 @@ function SearchInputField({
           placeholder={searchPlaceholder}
           value={searchPrompt}
           onChange={(e) => onSearchPromptChange(e.target.value)}
-          onFocus={handleFocus}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               if (showDropdown && activeIndex >= 0) {
@@ -191,7 +196,12 @@ function SearchInputField({
             }
             handleKeyDown(e); // ↑↓ Escape
           }}
-          className="flex-1 min-w-0 h-12 px-2 bg-transparent text-sm outline-none placeholder:text-muted-foreground dark:text-accent-foreground dark:placeholder:text-accent-foreground"
+          onFocus={(e) => {
+            handleFocus();
+            setIsFocused(true);
+          }}
+          onBlur={() => setIsFocused(false)}
+          className="flex-1 min-w-0 h-12 px-2 bg-transparent text-base outline-none placeholder:text-muted-foreground dark:text-accent-foreground dark:placeholder:text-accent-foreground"
         />
 
         {/* Divider + dataset selector + clear button */}
@@ -591,40 +601,8 @@ export function SearchHeader({
             />
           </div>
 
-          {/* Right: Hamburger + User */}
+          {/* Right: User + More */}
           <div className="flex items-center gap-2 shrink-0 ml-auto">
-            {/* Desktop: Dropdown hamburger (lg+) */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="hidden md:flex h-9 w-9"
-                >
-                  <Menu className="h-5 w-5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-52">
-                <HamburgerDropdownContent />
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            {/* Mobile/tablet: Sheet hamburger (below lg) */}
-            <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-              <SheetTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="md:hidden h-9 w-9"
-                >
-                  <Menu className="h-5 w-5" />
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="right" className="w-64 p-0">
-                <MobileSheetContent onClose={() => setMobileOpen(false)} />
-              </SheetContent>
-            </Sheet>
-
             {/* User menu / Sign In */}
             {isAuthenticated ? (
               <DropdownMenu modal={false}>
@@ -692,6 +670,38 @@ export function SearchHeader({
                 {tCommon("signIn")}
               </Button>
             )}
+
+            {/* Desktop: More options dropdown (⋮) */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="hidden md:flex h-9 w-9"
+                >
+                  <EllipsisVertical className="h-5 w-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                <HamburgerDropdownContent />
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Tablet: Sheet hamburger (below md) */}
+            <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+              <SheetTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="md:hidden h-9 w-9"
+                >
+                  <Menu className="h-5 w-5" />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="right" className="w-64 p-0">
+                <MobileSheetContent onClose={() => setMobileOpen(false)} />
+              </SheetContent>
+            </Sheet>
           </div>
         </div>
 


### PR DESCRIPTION
Improve responsive layout and UX across header, floating nav, search header, home and profile pages. Key changes:

- Profile page: tighten spacing and typography for small screens, make avatar and name sizes responsive, switch profile info layout to vertical on small screens, add truncation for email and adjust grid from two columns to single on narrow screens.
- Home search: add searchFocused state to apply subtle scale/transform on mobile when focused, increase input text size to improve readability, wire focus/blur handlers.
- Floating nav: split desktop and mobile/nav behaviors, always show LocaleSwitcher and ThemeToggle in desktop nav, simplify user label visibility, add a dedicated mobile right-side user menu (or sign-in button) and reorganize hamburger sheet trigger and sizing.
- Header: extract MobileSheetContent, centralize user menu into shared userMenu component, adjust desktop/tablet and mobile layouts (desktop single row, mobile two-row with centered logo), update hamburger sizing and sheet content usage.
- SearchHeader: add focused state for input to enable small-screen scaling, enlarge input text, replace duplicate hamburger controls with a desktop "more" (ellipsis) dropdown and a tablet sheet; reuse MobileSheetContent for sheet panels.

These changes standardize mobile/desktop behaviors, reduce duplicated code, improve accessibility/visual hierarchy on small devices, and centralize mobile sheet content for consistent navigation.