### PR TITLE
fix: approve_corpus_item 仅取最新待审记录避免 single() 报错

### DIFF
--- a/deno/main.tsx
+++ b/deno/main.tsx
@@ -1143,8 +1143,16 @@ curl -X POST http://localhost:8000/dev/get_update_history \
       .from("cantonese_corpus_update_history")
       .select("*")
       .eq("unique_id", unique_id)
+      .eq("status", "PENDING")
+      .order("created_at", { ascending: false })
+      .limit(1)
       .single();
     if (updateHistoryError) {
+      if (updateHistoryError.code === "PGRST116") {
+        context.response.status = 404;
+        context.response.body = { error: "No pending update history found for this unique_id" };
+        return;
+      }
       context.response.status = 500;
       context.response.body = { error: "Failed to get update history" };
       console.error("Error getting update history:", updateHistoryError);


### PR DESCRIPTION
当同一 unique_id 存在多条历史记录时，.single() 会因结果非单行而抛出 PGRST116。 通过过滤 status=PENDING、按 created_at 倒序并 limit(1) 精确锁定最新待审记录