### PR TITLE
Change game level rules to A–D and none

### DIFF
--- a/docs/miniprogram/business/yue-cube-game/api.md
+++ b/docs/miniprogram/business/yue-cube-game/api.md
@@ -112,7 +112,7 @@ const response = await wx.request({
   "total_time": 360,
   "completed_questions": 24,
   "accuracy": 0.75,
-  "level": "beginner"
+  "level": "A"
 }
 ```
 
@@ -698,7 +698,7 @@ const response = await wx.request({
 | `completed_questions` | 累计完成题数 |
 | `correct_questions` / `graded_questions` | 正确题数 / 已判分题数 |
 | `accuracy` | 正确率 |
-| `level` | 当前等级 |
+| `level` | 当前等级，`A` 粤语青铜、`B` 粤语铂金、`C` 粤语钻石、`D` 粤语王者、`none` 无等级 |
 | `current_streak_days` / `last_played_date` | 连续打卡天数 / 最近游戏日期 |
 | `context_completed` / `sound_completed` / `image_completed` | 分题型完成数 |
 | `context_correct` / `sound_correct` / `image_correct` | 分题型正确数 |

--- a/docs/miniprogram/business/yue-cube-game/business-logic.md
+++ b/docs/miniprogram/business/yue-cube-game/business-logic.md
@@ -286,19 +286,22 @@ overallPass = audioActive.pass && isCantonese.pass && imageAudioMatch.pass
   "total_time": 0,
   "completed_questions": 0,
   "accuracy": 0,
-  "level": "beginner"
+  "level": "none"
 }
 ```
 
 ### 6.3 等级规则
 
-当前按累计完成题数计算：
+等级由连续活跃天数和累计完成题数共同决定。当前小游戏服务没有单独记录登录流水，因此后端以 `game_player_progress.current_streak_days` 作为连续登录/活跃天数。
 
-| 条件 | level |
-|------|-------|
-| `< 50` | `beginner` |
-| `50 ~ 199` | `intermediate` |
-| `>= 200` | `advanced` |
+| 条件 | 展示等级 | 后端 `level` |
+|------|----------|---------------|
+| 连续 7 天活跃且累计完成 5 题 | 粤语青铜 | `A` |
+| 连续 30 天活跃且累计完成 20 题 | 粤语铂金 | `B` |
+| 连续 45 天活跃且累计完成 30 题 | 粤语钻石 | `C` |
+| 连续 60 天活跃且累计完成 40 题 | 粤语王者 | `D` |
+
+计算时按最高满足条件返回。若用户没有达到任何等级，或距离 `last_played_date` 已经连续 30 天未活跃，则等级归零，返回 `level = "none"`。
 
 ---
 

--- a/main/lib/services/yue-cube-game.ts
+++ b/main/lib/services/yue-cube-game.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 
 const SOUND_CORPUS_CATEGORY = "yywj2";
 const DEFAULT_DAILY_TARGET = 10;
+const LEVEL_NONE = "none";
 
 type JsonObject = Record<string, unknown>;
 
@@ -171,10 +172,21 @@ function startOfDay(date: Date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
-function levelForCompletedQuestions(completedQuestions: number) {
-  if (completedQuestions >= 200) return "advanced";
-  if (completedQuestions >= 50) return "intermediate";
-  return "beginner";
+function levelForProgress(
+  streakDays: number,
+  completedQuestions: number,
+  lastPlayedDate: Date | null,
+  today = startOfToday()
+) {
+  if (!lastPlayedDate || diffDays(lastPlayedDate, today) >= 30) {
+    return LEVEL_NONE;
+  }
+
+  if (streakDays >= 60 && completedQuestions >= 40) return "D";
+  if (streakDays >= 45 && completedQuestions >= 30) return "C";
+  if (streakDays >= 30 && completedQuestions >= 20) return "B";
+  if (streakDays >= 7 && completedQuestions >= 5) return "A";
+  return LEVEL_NONE;
 }
 
 function modeCompletedField(mode: YueCubeGameMode) {
@@ -221,7 +233,7 @@ async function updatePlayerProgress(
     correct_questions: correctQuestions,
     graded_questions: gradedQuestions,
     accuracy,
-    level: levelForCompletedQuestions(completedQuestions),
+    level: levelForProgress(streakDays, completedQuestions, today, today),
     current_streak_days: streakDays,
     last_played_date: today,
     context_completed:
@@ -313,11 +325,20 @@ export async function getPlayerProgress(userId: string) {
     where: { user_id: userId },
   });
 
+  const today = startOfToday();
+
   return {
     total_time: progress?.total_time_seconds ?? 0,
     completed_questions: progress?.completed_questions ?? 0,
     accuracy: progress?.accuracy ?? 0,
-    level: progress?.level ?? "beginner",
+    level: progress
+      ? levelForProgress(
+          progress.current_streak_days,
+          progress.completed_questions,
+          progress.last_played_date,
+          today
+        )
+      : LEVEL_NONE,
   };
 }
 


### PR DESCRIPTION
Replace the old beginner/intermediate/advanced levels with a new tiered system (A/B/C/D) and a "none" state. Docs updated to reflect new labels and examples and to explain that level is determined by consecutive active days + completed questions, and is reset to "none" after 30 days of inactivity. Service code updated: add LEVEL_NONE constant, implement levelForProgress(streakDays, completedQuestions, lastPlayedDate, today) with new thresholds, and use it in updatePlayerProgress and getPlayerProgress. Removes the previous levelForCompletedQuestions logic.