### PR TITLE
Add dataset & user filters to task-review UI

### DIFF
--- a/main/app/[locale]/(account)/account/data-annotation/page.tsx
+++ b/main/app/[locale]/(account)/account/data-annotation/page.tsx
@@ -1,15 +1,36 @@
 "use client";
 
+import { useEffect, useMemo } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { TaskListTab } from "@/components/task-review/TaskListTab";
 import { DashboardTab } from "@/components/task-review/DashboardTab";
 import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
+import { useUserTaskPermissions } from "@/lib/hooks/useTaskReview";
+import { useCategoryStore } from "@/lib/stores/category-store";
 
 export default function DataAnnotationPage() {
   const t = useTranslations("TaskReview");
   const searchParams = useSearchParams();
   const defaultTab = searchParams.get("tab") || "tasks";
+  const { fetchCategories, categories } = useCategoryStore();
+  const { data: permissions } = useUserTaskPermissions();
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  const datasets = useMemo(
+    () =>
+      (permissions?.writeCorpora ?? []).map((name) => {
+        const category = categories.find((cat) => cat.name === name);
+        return {
+          label: category?.nickname || category?.name || name,
+          value: name,
+        };
+      }),
+    [categories, permissions?.writeCorpora]
+  );
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -20,11 +41,11 @@ export default function DataAnnotationPage() {
         </TabsList>
 
         <TabsContent value="tasks">
-          <TaskListTab />
+          <TaskListTab datasets={datasets} />
         </TabsContent>
 
         <TabsContent value="dashboard">
-          <DashboardTab />
+          <DashboardTab datasets={datasets} />
         </TabsContent>
       </Tabs>
     </div>

--- a/main/app/api/data-annotation/tasks/stats/route.ts
+++ b/main/app/api/data-annotation/tasks/stats/route.ts
@@ -23,8 +23,11 @@ export async function GET(req: NextRequest) {
         assigneeRef: assigneeRef || undefined,
       });
 
-      // Enrich with user names and avatars
-      const userIds = data.filters.assigneeRefs ?? [];
+      // Match the mini-program flow: build the public user lookup from
+      // assigneeRefs present in stats items, not only from filters metadata.
+      const userIds = Array.from(
+        new Set((data.items ?? []).map((item) => item.assigneeRef).filter(Boolean))
+      );
       const userMap: Record<
         string,
         { name: string | null; avatar: string | null }
@@ -32,7 +35,10 @@ export async function GET(req: NextRequest) {
 
       if (userIds.length > 0) {
         const users = await prisma.user.findMany({
-          where: { id: { in: userIds } },
+          where: {
+            id: { in: userIds },
+            status: "ACTIVE",
+          },
           select: { id: true, name: true, image: true, wechatAvatar: true },
         });
         for (const u of users) {

--- a/main/components/task-review/DashboardTab.tsx
+++ b/main/components/task-review/DashboardTab.tsx
@@ -71,18 +71,30 @@ function aggregateByUser(items: TaskStatsItemWithUser[]): AggregatedUserStats[] 
 
 export function DashboardTab({ datasets }: DashboardTabProps) {
   const t = useTranslations("TaskReview");
-  const [corpusName, setCorpusName] = useState<string>(
-    datasets?.[0]?.value || ""
-  );
+  const [corpusName, setCorpusName] = useState<string>("all");
+  const [userValue, setUserValue] = useState<string>("all");
   const [userSearch, setUserSearch] = useState("");
   const [selectedUser, setSelectedUser] = useState<{
     id: string;
     name: string;
   } | null>(null);
+  const selectedCorpusName =
+    corpusName === "all" && datasets?.length
+      ? datasets.map((dataset) => dataset.value).join(",")
+      : corpusName === "all"
+        ? ""
+        : corpusName;
 
   const { data: stats, isLoading } = useTaskStats(
-    corpusName ? { corpusName } : null
+    selectedCorpusName ? { corpusName: selectedCorpusName } : null
   );
+  const currentDatasetLabel =
+    corpusName === "all"
+      ? datasets?.length
+        ? `${t("allDatasets")} (${datasets.map((dataset) => dataset.label).join(", ")})`
+        : t("allDatasets")
+      : datasets?.find((dataset) => dataset.value === corpusName)?.label ||
+        corpusName;
 
   // Aggregate per-user items from backend
   const userRows = useMemo(
@@ -90,11 +102,16 @@ export function DashboardTab({ datasets }: DashboardTabProps) {
     [stats?.items]
   );
 
-  const filteredRows = userSearch
-    ? userRows.filter((r) =>
-        r.name?.toLowerCase().includes(userSearch.toLowerCase())
-      )
-    : userRows;
+  const filteredRows = userRows.filter((row) => {
+    const matchesSelectedUser =
+      userValue === "all" || row.assigneeRef === userValue;
+    const matchesSearch =
+      !userSearch ||
+      (row.name || "")
+        .toLowerCase()
+        .includes(userSearch.toLowerCase());
+    return matchesSelectedUser && matchesSearch;
+  });
 
   return (
     <div className="space-y-4">
@@ -106,6 +123,7 @@ export function DashboardTab({ datasets }: DashboardTabProps) {
               <SelectValue placeholder={t("allDatasets")} />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value="all">{t("allDatasets")}</SelectItem>
               {datasets.map((ds) => (
                 <SelectItem key={ds.value} value={ds.value}>
                   {ds.label}
@@ -118,11 +136,25 @@ export function DashboardTab({ datasets }: DashboardTabProps) {
         {!datasets?.length && (
           <Input
             value={corpusName}
-            onChange={(e) => setCorpusName(e.target.value)}
+            onChange={(e) => setCorpusName(e.target.value || "all")}
             placeholder={t("dataset")}
             className="w-[200px]"
           />
         )}
+
+        <Select value={userValue} onValueChange={setUserValue}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder={t("user")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("all")}</SelectItem>
+            {userRows.map((user) => (
+              <SelectItem key={user.assigneeRef} value={user.assigneeRef}>
+                {user.name || user.assigneeRef}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
         <div className="flex items-center gap-2 border rounded-md px-2">
           <Search className="w-4 h-4 text-muted-foreground" />
@@ -133,6 +165,13 @@ export function DashboardTab({ datasets }: DashboardTabProps) {
             className="border-0 w-[160px] focus-visible:ring-0"
           />
         </div>
+      </div>
+
+      <div className="text-sm text-muted-foreground">
+        {t("dataset")}:{" "}
+        <span className="font-medium text-foreground">
+          {currentDatasetLabel}
+        </span>
       </div>
 
       {/* Summary Stats */}
@@ -227,7 +266,7 @@ export function DashboardTab({ datasets }: DashboardTabProps) {
           onClose={() => setSelectedUser(null)}
           userId={selectedUser.id}
           userName={selectedUser.name}
-          corpusName={corpusName}
+          corpusName={selectedCorpusName}
         />
       )}
     </div>

--- a/main/components/task-review/TaskListTab.tsx
+++ b/main/components/task-review/TaskListTab.tsx
@@ -17,28 +17,46 @@ import type { AgentTask, TaskListParams } from "@/lib/types/task-review";
 const UNCOMPLETED_STATUS = "created,notified,in_progress";
 const COMPLETED_STATUS = "completed";
 
-export function TaskListTab() {
+interface TaskListTabProps {
+  datasets?: { label: string; value: string }[];
+}
+
+export function TaskListTab({ datasets }: TaskListTabProps) {
   const t = useTranslations("TaskReview");
   const { fetchCategories, categories } = useCategoryStore();
 
   useEffect(() => { fetchCategories(); }, [fetchCategories]);
 
   const [taskTab, setTaskTab] = useState("uncompleted");
-  const [corpusName, setCorpusName] = useState<string>("");
+  const [corpusName, setCorpusName] = useState<string>("all");
   const [page, setPage] = useState(1);
   const [selectedTask, setSelectedTask] = useState<AgentTask | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
   const statusFilter = taskTab === "uncompleted" ? UNCOMPLETED_STATUS : COMPLETED_STATUS;
+  const datasetOptions =
+    datasets && datasets.length > 0
+      ? datasets
+      : categories.map((cat) => ({
+          label: cat.nickname || cat.name,
+          value: cat.name,
+        }));
+  const selectedCorpusName =
+    corpusName === "all"
+      ? datasetOptions.map((dataset) => dataset.value).join(",")
+      : corpusName;
 
   const params: TaskListParams = {
     status: statusFilter,
     page,
     pageSize: 10,
-    corpusName: corpusName || undefined,
+    corpusName: selectedCorpusName || undefined,
   };
 
-  const { data, isLoading, isFetching } = useTasks(params);
+  const { data, isLoading, isFetching } = useTasks(
+    params,
+    corpusName !== "all" || datasetOptions.length > 0
+  );
 
   // Filter out "reassigning" tasks on the client side (matching mini-program behavior)
   const allTasks = data?.items ?? [];
@@ -80,16 +98,16 @@ export function TaskListTab() {
         <div className="flex items-center gap-2">
           <Select
             value={corpusName}
-            onValueChange={(v) => { setCorpusName(v === "all" ? "" : v); setPage(1); }}
+            onValueChange={(v) => { setCorpusName(v); setPage(1); }}
           >
             <SelectTrigger className="w-[180px]">
               <SelectValue placeholder={t("allDatasets")} />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">{t("allDatasets")}</SelectItem>
-              {categories.map((cat) => (
-                <SelectItem key={cat.name} value={cat.name}>
-                  {cat.nickname || cat.name}
+              {datasetOptions.map((dataset) => (
+                <SelectItem key={dataset.value} value={dataset.value}>
+                  {dataset.label}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/main/lib/services/agent-error.ts
+++ b/main/lib/services/agent-error.ts
@@ -3,6 +3,13 @@ import { AgentApiError } from "@/lib/services/agent";
 
 export function handleAgentApiError(error: unknown, fallbackMessage = "Agent service request failed") {
   if (error instanceof AgentApiError) {
+    if (error.status === 401) {
+      return NextResponse.json(
+        { error: "Agent service authentication failed" },
+        { status: 502 }
+      );
+    }
+
     if (error.payload && typeof error.payload === "object") {
       return NextResponse.json(error.payload as Record<string, unknown>, {
         status: error.status,
@@ -21,4 +28,3 @@ export function handleAgentApiError(error: unknown, fallbackMessage = "Agent ser
     { status: 500 }
   );
 }
-


### PR DESCRIPTION
Pass dataset options (from category store and user permissions) into TaskListTab and DashboardTab, fetch categories on mount, and introduce an "all" dataset value that concatenates multiple corpus names for backend queries. DashboardTab: add user select, dataset label display, search + user filtering, and use the composed corpusName when requesting stats. TaskListTab: build dataset options from props or categories, use composed corpusName for task list requests, and conditionally trigger fetching. API: derive public user lookup from assigneeRefs present in stats items and only return ACTIVE users. Error handling: agent-error now maps AgentApiError 401 to a 502 JSON response indicating authentication failure.