### PR TITLE
Extract activity data and cast to Prisma types

### DIFF
--- a/main/app/api/admin/corpus-collection/activities/[id]/route.ts
+++ b/main/app/api/admin/corpus-collection/activities/[id]/route.ts
@@ -26,23 +26,25 @@ export async function PATCH(req: NextRequest, context: AppRouteContext) {
     if (!id) return NextResponse.json({ error: "Invalid activity id" }, { status: 400 });
 
     const body = await req.json();
+    const data = {
+      title: body.title,
+      slug: body.slug,
+      description: body.description,
+      rules: body.rules,
+      category: body.category,
+      tags: body.tags as Prisma.InputJsonValue | undefined,
+      submission_types: body.submissionTypes as Prisma.InputJsonValue | undefined,
+      reward_config: body.rewardConfig as Prisma.InputJsonValue | undefined,
+      media_requirements: body.mediaRequirements as Prisma.InputJsonValue | undefined,
+      banner_url: body.bannerUrl,
+      status: body.status,
+      starts_at: body.startsAt ? new Date(body.startsAt) : undefined,
+      ends_at: body.endsAt ? new Date(body.endsAt) : undefined,
+    } as Prisma.corpus_collection_activitiesUncheckedUpdateInput;
+
     const activity = await prisma.corpus_collection_activities.update({
       where: { id },
-      data: {
-        title: body.title,
-        slug: body.slug,
-        description: body.description,
-        rules: body.rules,
-        category: body.category,
-        tags: body.tags as Prisma.InputJsonValue | undefined,
-        submission_types: body.submissionTypes as Prisma.InputJsonValue | undefined,
-        reward_config: body.rewardConfig as Prisma.InputJsonValue | undefined,
-        media_requirements: body.mediaRequirements as Prisma.InputJsonValue | undefined,
-        banner_url: body.bannerUrl,
-        status: body.status,
-        starts_at: body.startsAt ? new Date(body.startsAt) : undefined,
-        ends_at: body.endsAt ? new Date(body.endsAt) : undefined,
-      },
+      data,
     });
     return NextResponse.json(serializeActivity(activity));
   });

--- a/main/app/api/admin/corpus-collection/activities/route.ts
+++ b/main/app/api/admin/corpus-collection/activities/route.ts
@@ -44,24 +44,24 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "title is required" }, { status: 400 });
     }
 
-    const activity = await prisma.corpus_collection_activities.create({
-      data: {
-        title: body.title,
-        slug: body.slug || undefined,
-        description: body.description,
-        rules: body.rules,
-        category: body.category,
-        tags: (body.tags ?? []) as Prisma.InputJsonValue,
-        submission_types: (body.submissionTypes ?? []) as Prisma.InputJsonValue,
-        reward_config: (body.rewardConfig ?? {}) as Prisma.InputJsonValue,
-        media_requirements: (body.mediaRequirements ?? {}) as Prisma.InputJsonValue,
-        banner_url: body.bannerUrl,
-        status: body.status || "draft",
-        starts_at: body.startsAt ? new Date(body.startsAt) : null,
-        ends_at: body.endsAt ? new Date(body.endsAt) : null,
-        created_by: userId,
-      },
-    });
+    const data = {
+      title: body.title,
+      slug: body.slug || undefined,
+      description: body.description,
+      rules: body.rules,
+      category: body.category,
+      tags: (body.tags ?? []) as Prisma.InputJsonValue,
+      submission_types: (body.submissionTypes ?? []) as Prisma.InputJsonValue,
+      reward_config: (body.rewardConfig ?? {}) as Prisma.InputJsonValue,
+      media_requirements: (body.mediaRequirements ?? {}) as Prisma.InputJsonValue,
+      banner_url: body.bannerUrl,
+      status: body.status || "draft",
+      starts_at: body.startsAt ? new Date(body.startsAt) : null,
+      ends_at: body.endsAt ? new Date(body.endsAt) : null,
+      created_by: userId,
+    } as Prisma.corpus_collection_activitiesUncheckedCreateInput;
+
+    const activity = await prisma.corpus_collection_activities.create({ data });
 
     return NextResponse.json(serializeActivity(activity), { status: 201 });
   });


### PR DESCRIPTION
Consolidate the activity payload into a typed `data` object in both POST and PATCH handlers. The changes cast payloads to Prisma.corpus_collection_activitiesUncheckedCreateInput/UncheckedUpdateInput, centralize fields (including JSON fields and date conversions), and pass the `data` object to prisma.create/update to reduce duplication and improve typing.