### PR TITLE
Add home submissions feed API and docs

### DIFF
--- a/docs/miniprogram/business/corpus-collection-app/api-contract-amendments.md
+++ b/docs/miniprogram/business/corpus-collection-app/api-contract-amendments.md
@@ -402,10 +402,64 @@ main/prisma/schema.prisma
 main/prisma/migrations/20260520090000_extend_corpus_collection_contract/migration.sql
 ```
 
-## 八、已实施接口清单
+## 八、首页投稿流分页接口已实施
+
+新增小红书式首页投稿瀑布流接口：
+
+```text
+GET /api/miniprogram/corpus_collection/home/submissions
+```
+
+用途：
+
+```text
+GET /home
+  -> 获取 Banner、活动、快捷入口和首屏聚合信息
+
+GET /home/submissions?page=1&pageSize=20
+  -> 分页获取首页投稿卡片，用于无限滚动
+```
+
+已支持参数：
+
+| 参数名 | 类型 | 必填 | 默认值 | 说明 |
+|-------|------|-----|-------|------|
+| `page` | number | 否 | `1` | 页码 |
+| `pageSize` | number | 否 | `20` | 每页数量，最大 30 |
+| `sort` | string | 否 | `latest` | `latest`、`likes`、`views` |
+| `type` / `submissionType` | string | 否 | - | 投稿类型 |
+| `tag` | string | 否 | - | 分类标签 |
+| `activityId` | string | 否 | - | 活动 ID |
+| `isFeatured` | boolean | 否 | - | 是否只看精选 |
+| `showOnHome` | boolean | 否 | - | 是否只看后台标记首页展示的投稿 |
+
+响应卡片已包含瀑布流所需字段：
+
+```json
+{
+  "coverUrl": "https://oss/1.jpg",
+  "coverWidth": 1080,
+  "coverHeight": 1440,
+  "coverAspectRatio": 0.75,
+  "liked": false,
+  "pagination": {
+    "hasMore": true
+  }
+}
+```
+
+已实施位置：
+
+```text
+main/app/api/miniprogram/corpus_collection/home/submissions/route.ts
+main/lib/services/corpus-collection.ts
+```
+
+## 九、已实施接口清单
 
 ```text
 GET    /api/miniprogram/corpus_collection/home
+GET    /api/miniprogram/corpus_collection/home/submissions
 GET    /api/miniprogram/corpus_collection/activities/{id}
 GET    /api/miniprogram/corpus_collection/activities/{id}/works
 GET    /api/miniprogram/corpus_collection/submissions/mine
@@ -418,7 +472,7 @@ PATCH  /api/miniprogram/corpus_collection/messages/{id}/read
 PATCH  /api/miniprogram/corpus_collection/messages/read-all
 ```
 
-## 九、验证结果
+## 十、验证结果
 
 已执行并通过：
 
@@ -426,4 +480,3 @@ PATCH  /api/miniprogram/corpus_collection/messages/read-all
 pnpm exec prisma generate
 pnpm exec tsc --noEmit
 ```
-

--- a/docs/miniprogram/business/corpus-collection-app/api.md
+++ b/docs/miniprogram/business/corpus-collection-app/api.md
@@ -87,6 +87,107 @@ const response = await wx.request({
 }
 ```
 
+### 1.2 获取首页投稿流
+
+首页投稿流用于小红书式瀑布流/无限滚动展示。该接口只返回已审核通过且公开的投稿，和 `GET /home` 分离，前端首屏可先调用 `/home` 获取 Banner、活动和快捷入口，再按页调用本接口加载投稿卡片。
+
+#### 接口信息
+
+- **URL**: `/api/miniprogram/corpus_collection/home/submissions`
+- **方法**: `GET`
+- **认证**: 需要 Bearer Token
+
+#### 请求参数 (Query String)
+
+| 参数名 | 类型 | 必填 | 默认值 | 说明 |
+|-------|------|-----|-------|------|
+| `page` | number | 否 | `1` | 页码，从 1 开始 |
+| `pageSize` | number | 否 | `20` | 每页数量，最大 30 |
+| `sort` | string | 否 | `latest` | `latest` 最新、`likes` 点赞量、`views` 浏览量 |
+| `type` / `submissionType` | string | 否 | - | 投稿类型 |
+| `tag` | string | 否 | - | 分类标签 |
+| `activityId` | string | 否 | - | 活动 ID |
+| `isFeatured` | boolean | 否 | - | 是否只看精选 |
+| `showOnHome` | boolean | 否 | - | 是否只看后台标记为首页展示的投稿 |
+
+默认不强制 `showOnHome=true`，避免首页流内容不足；如果产品需要完全由后台运营控制首页流，前端传 `showOnHome=true`。
+
+#### 请求示例
+
+```javascript
+const response = await wx.request({
+  url: 'https://search.aidimsum.com/api/miniprogram/corpus_collection/home/submissions?page=1&pageSize=20&sort=latest',
+  method: 'GET',
+  header: {
+    'Authorization': `Bearer ${accessToken}`
+  }
+});
+```
+
+#### 成功响应 (200)
+
+```json
+{
+  "items": [
+    {
+      "id": "sub_001",
+      "title": "月光光",
+      "intro": "粤语童谣朗诵",
+      "submissionType": "诗歌",
+      "tags": ["童谣"],
+      "coverUrl": "https://oss/1.jpg",
+      "imageUrls": ["https://oss/1.jpg"],
+      "coverWidth": 1080,
+      "coverHeight": 1440,
+      "coverAspectRatio": 0.75,
+      "author": {
+        "id": "user_001",
+        "name": "用户昵称",
+        "avatar": "https://wx.qlogo.cn/..."
+      },
+      "activity": {
+        "id": "act_001",
+        "title": "粤语诗歌朗诵赛"
+      },
+      "likeCount": 20,
+      "commentCount": 3,
+      "shareCount": 5,
+      "viewCount": 123,
+      "isFeatured": true,
+      "showOnHome": false,
+      "liked": false,
+      "createdAt": "2026-05-01T10:00:00.000Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "pageSize": 20,
+    "total": 120,
+    "hasMore": true
+  }
+}
+```
+
+字段说明：
+
+| 字段 | 说明 |
+|------|------|
+| `coverUrl` | 瀑布流卡片主图，优先取第一张图片 |
+| `coverWidth` / `coverHeight` | 上传媒体元数据中存在宽高时返回，否则为 `null` |
+| `coverAspectRatio` | `coverWidth / coverHeight`，前端可用于预占瀑布流高度 |
+| `liked` | 当前登录用户是否已点赞 |
+| `hasMore` | 是否还有下一页，适合 `onReachBottom` 或虚拟列表继续加载 |
+
+#### 错误响应
+
+**401 Unauthorized**
+
+```json
+{
+  "error": "Invalid or expired token"
+}
+```
+
 ---
 
 ## 二、活动接口

--- a/docs/miniprogram/business/corpus-collection-app/business-logic.md
+++ b/docs/miniprogram/business/corpus-collection-app/business-logic.md
@@ -91,7 +91,7 @@ agent API 详细定义见：`docs/archive/submission-service-api.md`。
   -> 获取首页数据
   -> 展示当前活动 Banner
   -> 展示快捷入口
-  -> 展示最新审核通过投稿
+  -> 分页加载首页投稿流
   -> 展示精选内容
 ```
 
@@ -99,9 +99,34 @@ agent API 详细定义见：`docs/archive/submission-service-api.md`。
 
 - 当前进行中活动
 - Banner 图片
-- 最新审核通过投稿
+- 首屏少量最新审核通过投稿
 - 精选投稿
 - 快捷入口配置
+
+首页投稿流需单独分页加载，不再依赖首页聚合接口一次性返回全部内容：
+
+```text
+GET /api/miniprogram/corpus_collection/home
+  -> 首屏聚合数据，适合 Banner、活动、快捷入口
+
+GET /api/miniprogram/corpus_collection/home/submissions?page=1&pageSize=20
+  -> 首页投稿瀑布流，适合小红书式双列卡片、无限滚动
+```
+
+首页投稿流展示规则：
+
+```text
+review_status = approved
+visibility = public
+```
+
+若运营希望完全控制首页出现的作品，可让前端传：
+
+```text
+showOnHome = true
+```
+
+投稿流排序默认按最新发布倒序，也支持按点赞数或浏览数排序。接口返回 `hasMore`，小程序端滚动到底部时继续请求下一页。
 
 ### 5.2 用户投稿流程
 

--- a/docs/miniprogram/business/corpus-collection-app/miniprogram-api-change-notes.md
+++ b/docs/miniprogram/business/corpus-collection-app/miniprogram-api-change-notes.md
@@ -415,3 +415,71 @@ GET /api/miniprogram/corpus_collection/submissions/{id}
 10. 不做投稿删除入口。
 11. 精选角标使用 `isFeatured`。
 
+## 十、首页投稿流分页接口
+
+原需求：
+
+```text
+首页投稿需要小红书式流式展示，投稿列表要单独分页加载。
+```
+
+已新增接口：
+
+```text
+GET /api/miniprogram/corpus_collection/home/submissions
+```
+
+支持参数：
+
+| 参数名 | 类型 | 说明 |
+|-------|------|------|
+| `page` | number | 页码，默认 1 |
+| `pageSize` | number | 每页数量，默认 20，最大 30 |
+| `sort` | string | `latest`、`likes`、`views` |
+| `type` / `submissionType` | string | 投稿类型 |
+| `tag` | string | 分类标签 |
+| `activityId` | string | 活动 ID |
+| `isFeatured` | boolean | 是否只看精选 |
+| `showOnHome` | boolean | 是否只看后台标记首页展示的投稿 |
+
+成功响应包含：
+
+```json
+{
+  "items": [
+    {
+      "id": "sub_001",
+      "title": "月光光",
+      "coverUrl": "https://oss/1.jpg",
+      "coverAspectRatio": 0.75,
+      "author": {
+        "id": "user_001",
+        "name": "用户昵称",
+        "avatar": "https://wx.qlogo.cn/..."
+      },
+      "likeCount": 20,
+      "commentCount": 3,
+      "viewCount": 123,
+      "isFeatured": true,
+      "showOnHome": false,
+      "liked": false
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "pageSize": 20,
+    "total": 120,
+    "hasMore": true
+  }
+}
+```
+
+小程序首页建议：
+
+```text
+首屏进入：GET /home 获取 Banner、活动、快捷入口
+投稿瀑布流：GET /home/submissions?page=1&pageSize=20
+继续加载：hasMore=true 时 page + 1
+```
+
+默认返回所有已通过且公开的投稿；如果产品需要只展示运营挑选内容，调用时传 `showOnHome=true`。

--- a/main/app/api/miniprogram/corpus_collection/home/submissions/route.ts
+++ b/main/app/api/miniprogram/corpus_collection/home/submissions/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireMiniprogramAuth } from "@/lib/miniprogram-auth";
+import {
+  listHomeFeedSubmissions,
+  parseBigIntId,
+  parsePositiveInt,
+} from "@/lib/services/corpus-collection";
+
+function parseOptionalBoolean(value: string | null) {
+  if (value === null) return undefined;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+function parseFeedSort(value: string | null) {
+  if (value === "likes" || value === "views") return value;
+  return "latest";
+}
+
+export async function GET(req: NextRequest) {
+  const searchParams = new URL(req.url).searchParams;
+  const page = parsePositiveInt(searchParams.get("page"), 1);
+  const pageSize = parsePositiveInt(searchParams.get("pageSize"), 20, 30);
+  const sort = parseFeedSort(searchParams.get("sort"));
+  const type = searchParams.get("type") ?? searchParams.get("submissionType");
+  const tag = searchParams.get("tag");
+  const activityId = parseBigIntId(searchParams.get("activityId"));
+  const featured = parseOptionalBoolean(searchParams.get("isFeatured"));
+  const showOnHome = parseOptionalBoolean(searchParams.get("showOnHome"));
+
+  return requireMiniprogramAuth(req, async (_req, user) => {
+    try {
+      return NextResponse.json(
+        await listHomeFeedSubmissions({
+          activityId,
+          featured,
+          showOnHome,
+          type,
+          tag,
+          page,
+          pageSize,
+          sort,
+          viewerId: user.userId,
+        })
+      );
+    } catch (error) {
+      console.error("[CorpusCollection] Failed to load home submissions", error);
+      return NextResponse.json(
+        { error: "Failed to load home submissions" },
+        { status: 500 }
+      );
+    }
+  });
+}

--- a/main/lib/services/corpus-collection.ts
+++ b/main/lib/services/corpus-collection.ts
@@ -69,6 +69,19 @@ function getSubmissionImages(submission: any) {
     .map((item: any) => item.url);
 }
 
+function getCoverMetadata(submission: any) {
+  const cover = (submission.media ?? []).find((item: any) => item.media_type === "image");
+  const metadata = cover?.metadata;
+  const width = Number(metadata?.width);
+  const height = Number(metadata?.height);
+
+  return {
+    coverUrl: cover?.url ?? null,
+    coverWidth: Number.isFinite(width) && width > 0 ? width : null,
+    coverHeight: Number.isFinite(height) && height > 0 ? height : null,
+  };
+}
+
 export function serializeActivity(activity: any) {
   return {
     id: activity.id.toString(),
@@ -187,11 +200,90 @@ export function serializeHomeSubmission(submission: any) {
   };
 }
 
+export function serializeHomeFeedSubmission(submission: any, viewerLiked?: boolean) {
+  const author = serializeUser(submission.user);
+  const imageUrls = getSubmissionImages(submission);
+  const cover = getCoverMetadata(submission);
+  const coverAspectRatio =
+    cover.coverWidth && cover.coverHeight ? cover.coverWidth / cover.coverHeight : null;
+
+  return {
+    id: submission.id.toString(),
+    title: submission.title,
+    intro: submission.intro,
+    submissionType: submission.submission_type,
+    tags: submission.tags,
+    coverUrl: cover.coverUrl ?? imageUrls[0] ?? "",
+    imageUrls,
+    coverWidth: cover.coverWidth,
+    coverHeight: cover.coverHeight,
+    coverAspectRatio,
+    author: {
+      id: author?.id ?? "",
+      name: author?.name ?? "用户昵称",
+      avatar: author?.avatar ?? "",
+    },
+    activity: submission.activity
+      ? {
+          id: submission.activity.id.toString(),
+          title: submission.activity.title,
+        }
+      : null,
+    likeCount: submission.like_count,
+    commentCount: submission.comment_count,
+    shareCount: submission.share_count,
+    viewCount: submission.view_count,
+    isFeatured: submission.is_featured,
+    showOnHome: submission.show_on_home,
+    liked: viewerLiked,
+    createdAt: submission.created_at?.toISOString?.() ?? undefined,
+  };
+}
+
 export const submissionInclude = {
   activity: { select: { id: true, title: true, starts_at: true, ends_at: true } },
   user: { select: { id: true, name: true, image: true, wechatAvatar: true } },
   media: { orderBy: { sort_order: "asc" } },
 } satisfies Prisma.corpus_collection_submissionsInclude;
+
+export function buildPublicSubmissionWhere(options: {
+  activityId?: bigint | null;
+  featured?: boolean;
+  showOnHome?: boolean;
+  type?: string | null;
+  tag?: string | null;
+  awardStatus?: string | null;
+}) {
+  return {
+    ...PUBLIC_SUBMISSION_WHERE,
+    activity_id: options.activityId ?? undefined,
+    is_featured: options.featured === undefined ? undefined : options.featured,
+    show_on_home: options.showOnHome === undefined ? undefined : options.showOnHome,
+    submission_type: options.type || undefined,
+    award_status: options.awardStatus || undefined,
+    tags: options.tag ? { array_contains: options.tag } : undefined,
+  } satisfies Prisma.corpus_collection_submissionsWhereInput;
+}
+
+export function getPublicSubmissionOrderBy(sort?: "latest" | "likes" | "views") {
+  if (sort === "likes") {
+    return [
+      { like_count: "desc" },
+      { created_at: "desc" },
+    ] satisfies Prisma.corpus_collection_submissionsOrderByWithRelationInput[];
+  }
+
+  if (sort === "views") {
+    return [
+      { view_count: "desc" },
+      { created_at: "desc" },
+    ] satisfies Prisma.corpus_collection_submissionsOrderByWithRelationInput[];
+  }
+
+  return {
+    created_at: "desc",
+  } satisfies Prisma.corpus_collection_submissionsOrderByWithRelationInput;
+}
 
 export async function listPublicSubmissions(options: {
   activityId?: bigint | null;
@@ -202,26 +294,15 @@ export async function listPublicSubmissions(options: {
   awardStatus?: string | null;
   page: number;
   pageSize: number;
-  sort?: "latest" | "likes";
+  sort?: "latest" | "likes" | "views";
   includeRaw?: boolean;
 }) {
-  const where: Prisma.corpus_collection_submissionsWhereInput = {
-    ...PUBLIC_SUBMISSION_WHERE,
-    activity_id: options.activityId ?? undefined,
-    is_featured: options.featured === undefined ? undefined : options.featured,
-    show_on_home: options.showOnHome === undefined ? undefined : options.showOnHome,
-    submission_type: options.type || undefined,
-    award_status: options.awardStatus || undefined,
-    tags: options.tag ? { array_contains: options.tag } : undefined,
-  };
+  const where = buildPublicSubmissionWhere(options);
   const [items, total] = await Promise.all([
     prisma.corpus_collection_submissions.findMany({
       where,
       include: submissionInclude,
-      orderBy:
-        options.sort === "likes"
-          ? [{ like_count: "desc" }, { created_at: "desc" }]
-          : { created_at: "desc" },
+      orderBy: getPublicSubmissionOrderBy(options.sort),
       skip: (options.page - 1) * options.pageSize,
       take: options.pageSize,
     }),
@@ -232,6 +313,54 @@ export async function listPublicSubmissions(options: {
     items: items.map((item) => serializeSubmission(item)),
     ...(options.includeRaw ? { rawItems: items } : {}),
     pagination: { page: options.page, pageSize: options.pageSize, total },
+  };
+}
+
+export async function listHomeFeedSubmissions(options: {
+  activityId?: bigint | null;
+  featured?: boolean;
+  showOnHome?: boolean;
+  type?: string | null;
+  tag?: string | null;
+  page: number;
+  pageSize: number;
+  sort?: "latest" | "likes" | "views";
+  viewerId?: string;
+}) {
+  const where = buildPublicSubmissionWhere(options);
+  const [items, total] = await Promise.all([
+    prisma.corpus_collection_submissions.findMany({
+      where,
+      include: submissionInclude,
+      orderBy: getPublicSubmissionOrderBy(options.sort),
+      skip: (options.page - 1) * options.pageSize,
+      take: options.pageSize,
+    }),
+    prisma.corpus_collection_submissions.count({ where }),
+  ]);
+
+  const likedSubmissionIds = new Set<bigint>();
+  if (options.viewerId && items.length > 0) {
+    const likes = await prisma.corpus_collection_likes.findMany({
+      where: {
+        user_id: options.viewerId,
+        submission_id: { in: items.map((item) => item.id) },
+      },
+      select: { submission_id: true },
+    });
+    likes.forEach((like) => likedSubmissionIds.add(like.submission_id));
+  }
+
+  return {
+    items: items.map((item) =>
+      serializeHomeFeedSubmission(item, likedSubmissionIds.has(item.id))
+    ),
+    pagination: {
+      page: options.page,
+      pageSize: options.pageSize,
+      total,
+      hasMore: options.page * options.pageSize < total,
+    },
   };
 }
 


### PR DESCRIPTION
Introduce a paginated home submissions (waterfall) endpoint and related service logic. Adds a new API route (main/app/api/miniprogram/corpus_collection/home/submissions/route.ts) that requires miniprogram auth and parses pagination, sort, filters and boolean flags. Extends main/lib/services/corpus-collection.ts with cover metadata extraction, serializeHomeFeedSubmission, buildPublicSubmissionWhere, getPublicSubmissionOrderBy and listHomeFeedSubmissions (including viewer liked detection), and refactors listPublicSubmissions to use the new helpers. Updates documentation across docs/... (api-contract-amendments.md, api.md, business-logic.md, miniprogram-api-change-notes.md) describing the endpoint, query params, response shape (coverAspectRatio, hasMore, etc.), and usage guidance (pageSize max 30, sorting by latest/likes/views).