### PR TITLE
Support timeStatus filter for activities API

### DIFF
--- a/docs/miniprogram/business/corpus-collection-app/api.md
+++ b/docs/miniprogram/business/corpus-collection-app/api.md
@@ -205,12 +205,21 @@ const response = await wx.request({
 | 参数名 | 类型 | 必填 | 默认值 | 说明 |
 |-------|------|-----|-------|------|
 | `status` | string | 否 | `published` | 活动状态 |
+| `timeStatus` | string | 否 | - | 活动时间状态：`not_started` 未开始、`ongoing` 进行中、`ended` 已结束 |
 | `keyword` / `q` | string | 否 | - | 活动标题、介绍模糊搜索关键词 |
 | `includeExpired` | boolean | 否 | `false` | 是否包含已过期活动；默认仅返回未过期活动 |
 | `page` | number | 否 | `1` | 页码 |
 | `pageSize` | number | 否 | `10` | 每页数量 |
 
-排序规则：默认返回未过期活动，按活动热度和时间倒序；当 `includeExpired=true` 时，过期活动排在未过期活动之后。
+排序规则：默认返回未过期活动，按活动热度和时间倒序；当 `includeExpired=true` 时，过期活动排在未过期活动之后。传入 `timeStatus` 时，由 `timeStatus` 接管时间筛选，不再叠加 `includeExpired=false` 的默认未过期过滤。
+
+筛选当前可投稿活动列表时，可使用：
+
+```text
+GET /api/miniprogram/corpus_collection/activities?timeStatus=ongoing
+```
+
+由于 `status` 默认值为 `published`，上述请求会返回已发布且时间进行中的活动。
 
 #### 成功响应 (200)
 
@@ -223,6 +232,8 @@ const response = await wx.request({
       "description": "征集粤语诗歌朗诵作品",
       "bannerUrl": "https://oss/banner.jpg",
       "status": "published",
+      "timeStatus": "ongoing",
+      "canSubmit": true,
       "startsAt": "2026-05-01T00:00:00.000Z",
       "endsAt": "2026-05-31T23:59:59.000Z",
       "submissionCount": 120,

--- a/main/app/api/miniprogram/corpus_collection/activities/route.ts
+++ b/main/app/api/miniprogram/corpus_collection/activities/route.ts
@@ -12,6 +12,7 @@ import {
 export async function GET(req: NextRequest) {
   const searchParams = new URL(req.url).searchParams;
   const status = searchParams.get("status") || "published";
+  const timeStatus = searchParams.get("timeStatus");
   const keyword = searchParams.get("keyword") || searchParams.get("q");
   const includeExpired = searchParams.get("includeExpired") === "true";
   const page = parsePositiveInt(searchParams.get("page"), 1);
@@ -22,7 +23,18 @@ export async function GET(req: NextRequest) {
       const now = new Date();
       const and: Prisma.corpus_collection_activitiesWhereInput[] = [{ status }];
 
-      if (!includeExpired) {
+      if (timeStatus === "not_started") {
+        and.push({ starts_at: { gt: now } });
+      } else if (timeStatus === "ongoing") {
+        and.push({
+          AND: [
+            { OR: [{ starts_at: null }, { starts_at: { lte: now } }] },
+            { OR: [{ ends_at: null }, { ends_at: { gte: now } }] },
+          ],
+        });
+      } else if (timeStatus === "ended") {
+        and.push({ ends_at: { lt: now } });
+      } else if (!includeExpired) {
         and.push({ OR: [{ ends_at: null }, { ends_at: { gte: now } }] });
       }
 


### PR DESCRIPTION
Add a new timeStatus query parameter to the corpus-collection activities endpoint and docs. The route now parses timeStatus and applies time-based filters for not_started, ongoing, and ended states (these override the default includeExpired=false behavior). Documentation updated with the parameter, example request (GET ...?timeStatus=ongoing), and sample response fields (timeStatus and canSubmit).